### PR TITLE
Remove forced install of EPEL

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -90,7 +90,6 @@ function ensure_mandatory_variables_set {
 
 function install_yum_dependencies {
   yum -y update
-  yum -y install epel-release
   yum -y install git
   yum -y install ansible
 }


### PR DESCRIPTION
As RH7 may do this differently we will no longer install EPEL and
instead move it to documentation as a required step before running
the installer process.

Closes #50.