### PR TITLE
Ensure IdP credential permissions set correctly

### DIFF
--- a/tasks/idp.yml
+++ b/tasks/idp.yml
@@ -438,6 +438,9 @@
   - conf/c14n/subject-c14n-events-flow.xml
   - conf/c14n/simple-subject-c14n-config.xml
   - conf/intercept/consent-intercept-config.xml
+  - credentials/idp-encryption.key
+  - credentials/idp-signing.key
+  - credentials/idp-backchannel.p12
 
 - name: 'Install IdP systemd unit'
   template:


### PR DESCRIPTION
The permissions for the files in Shibboleth IdP's credential directory
weren't being set on an initial run of `bootstrap.sh`. Now they will be
set so the jetty user has access.

Closes #76.