### PR TITLE
Download jetty binary from AWS S3

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -1,9 +1,11 @@
 ---
 - hosts: idp-servers
   vars:
+    aaf_binaries:
+      baseurl: https://aaf-binaries.s3-ap-southeast-2.amazonaws.com 
     software:
       jetty:
-        baseurl: http://download.eclipse.org/jetty
+        baseurl: "{{ aaf_binaries.baseurl }}/jetty"
         version: 9.3.5.v20151012
         sha256sum: 24e80e350fcc9749aa4a29913c34917ad238a0fa3abdb7d7c9b42dc40bdf0f9b
       shib_idp:
@@ -17,7 +19,7 @@
       version: "{{ software.jetty.version }}"
       sha256sum: "{{ software.jetty.sha256sum }}"
       root: /opt/jetty
-      url: "{{ software.jetty.baseurl }}/{{ software.jetty.version }}/dist/jetty-distribution-{{ software.jetty.version }}.tar.gz"
+      url: "{{ software.jetty.baseurl }}/jetty-distribution-{{ software.jetty.version }}.tar.gz"
       home: /opt/jetty/jetty-distribution-{{ software.jetty.version }}
       base: /opt/shibboleth/jetty
       current: /opt/jetty/current


### PR DESCRIPTION
The Jetty download site only maintains the current and previous versions.
All ealier versions are moved the the Archive site. This will break the
installer if there are a number of Jetty upgrades between Installer upgrades.