### PR TITLE
Feature/relying party

### DIFF
--- a/assets/idp.example.edu.dist/idp/conf/relying-party.xml
+++ b/assets/idp.example.edu.dist/idp/conf/relying-party.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:c="http://www.springframework.org/schema/c"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd"
+                           
+       default-init-method="initialize"
+       default-destroy-method="destroy">
+
+    <!--
+    Unverified RP configuration, defaults to no support for any profiles. Add <ref> elements to the list
+    to enable specific default profile settings (as below), or create new beans inline to override defaults.
+    
+    "Unverified" typically means the IdP has no metadata, or equivalent way of assuring the identity and
+    legitimacy of a requesting system. To run an "open" IdP, you can enable profiles here.
+    -->
+    <bean id="shibboleth.UnverifiedRelyingParty" parent="RelyingParty">
+        <property name="profileConfigurations">
+            <list>
+            <!-- <bean parent="SAML2.SSO" p:encryptAssertions="false" /> -->
+            </list>
+        </property>
+    </bean>
+
+    <!--
+    Default configuration, with default settings applied for all profiles, and enables
+    the attribute-release consent flow.
+    -->
+    <bean id="shibboleth.DefaultRelyingParty" parent="RelyingParty">
+        <property name="profileConfigurations">
+            <list>
+                <bean parent="Shibboleth.SSO" p:postAuthenticationFlows="attribute-release" />
+                <ref bean="SAML1.AttributeQuery" />
+                <ref bean="SAML1.ArtifactResolution" />
+                <bean parent="SAML2.SSO" p:postAuthenticationFlows="attribute-release" />
+                <ref bean="SAML2.ECP" />
+                <ref bean="SAML2.Logout" />
+                <ref bean="SAML2.AttributeQuery" />
+                <ref bean="SAML2.ArtifactResolution" />
+                <ref bean="Liberty.SSOS" />
+            </list>
+        </property>
+    </bean>
+
+    <!-- Container for any overrides you want to add. -->
+
+    <util:list id="shibboleth.RelyingPartyOverrides">
+    
+        <!--
+        Override example that identifies a single RP by name and configures it
+        for SAML 2 SSO without encryption. This is a common "vendor" scenario.
+        -->
+        <!--
+        <bean parent="RelyingPartyByName" c:relyingPartyIds="https://sp.example.org">
+            <property name="profileConfigurations">
+                <list>
+                    <bean parent="SAML2.SSO" p:encryptAssertions="false" />
+                </list>
+            </property>
+        </bean>
+        -->
+        
+    </util:list>
+
+</beans>

--- a/tasks/idp.yml
+++ b/tasks/idp.yml
@@ -449,12 +449,20 @@
 
 - name: 'Set Shibboleth logback configuration'
   template:
-    dest: '{{ shib_idp.home }}/conf/logback.xml'
     src: 'assets/{{inventory_hostname}}/idp/conf/logback.xml'
+    dest: '{{ shib_idp.home }}/conf/logback.xml'
     owner: root
     group: jetty
     mode: 0640
     backup: yes
+
+- name: 'Set Shibboleth relying-party.xml'
+  copy:
+    src: assets/{{inventory_hostname}}/idp/conf/relying-party.xml'
+    dest: '{{ shib_idp.home }}/conf/relying-party.xml'
+    owner: root
+    group: jetty
+    mode: 0640  
 
 - name: 'Set authn/general-authn.xml'
   copy:

--- a/tasks/idp.yml
+++ b/tasks/idp.yml
@@ -458,7 +458,7 @@
 
 - name: 'Set Shibboleth relying-party.xml'
   copy:
-    src: assets/{{inventory_hostname}}/idp/conf/relying-party.xml'
+    src: 'assets/{{inventory_hostname}}/idp/conf/relying-party.xml'
     dest: '{{ shib_idp.home }}/conf/relying-party.xml'
     owner: root
     group: jetty


### PR DESCRIPTION
resolves #110 
Make the relying-party.xml file available to admins to modify. This allows them to black list SP from consent. I.E. consent page not show for listed SPs.

Tested with both a new install and upgrade