### PR TITLE
Feature/upgrade jetty 9 3 11

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -6,7 +6,7 @@
     download:
       jetty:
         baseurl: "{{ aaf_binaries.baseurl }}/jetty"
-        version: 9.3.11.v201600721
+        version: 9.3.11.v20160721
         sha256sum: 6f720a39324ba02491c5dd598039f9cda1746d45c26594f8189692058f9f4264
       shib_idp:
         baseurl: "{{ aaf_binaries.baseurl }}/shibboleth"

--- a/site.yml
+++ b/site.yml
@@ -6,8 +6,8 @@
     download:
       jetty:
         baseurl: "{{ aaf_binaries.baseurl }}/jetty"
-        version: 9.3.8.v20160314
-        sha256sum: fc4136c0abf8f86d99de1b11b3d2323bffda0d538a0f654bf741f5e84ea992bf
+        version: 9.3.11.v201600721
+        sha256sum: 6f720a39324ba02491c5dd598039f9cda1746d45c26594f8189692058f9f4264
       shib_idp:
         baseurl: "{{ aaf_binaries.baseurl }}/shibboleth"
         version: 3.2.1


### PR DESCRIPTION
Tested on new and upgrade.

Jetty version 9.3.11 has been uploaded to AWS s3

resolves #154 