### PR TITLE
Fixed typo ShibCas -> Shibcas

### DIFF
--- a/assets/idp.example.edu.dist/idp/conf/credentials.xml
+++ b/assets/idp.example.edu.dist/idp/conf/credentials.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:c="http://www.springframework.org/schema/c"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd"
+                           
+       default-init-method="initialize"
+       default-destroy-method="destroy">
+
+    <!--
+    NOTE: if you're using a legacy relying-party.xml file from a V2 configuration, this file is ignored.
+
+    This defines the signing and encryption key and certificate pairs referenced by your relying-party.xml
+    configuration. You don't normally need to touch this, unless you have advanced requirements such as
+    supporting multiple sets of keys for different relying parties, in which case you may want to define
+    all your credentials here for convenience.
+    -->
+
+    <!--
+    The list of ALL of your IdP's signing credentials. If you define additional signing credentials,
+    for example for specific relying parties or different key types, make sure to include them within this list.
+    -->
+    <util:list id="shibboleth.SigningCredentials">
+        <ref bean="shibboleth.DefaultSigningCredential" />
+    </util:list>
+    
+    <!-- Your IdP's default signing key, set via property file. -->
+    <bean id="shibboleth.DefaultSigningCredential"
+        class="net.shibboleth.idp.profile.spring.factory.BasicX509CredentialFactoryBean"
+        p:privateKeyResource="%{idp.signing.key}"
+        p:certificateResource="%{idp.signing.cert}"
+        p:entityId-ref="entityID" />
+        
+    <!--
+    The list of ALL of your IdP's encryption credentials. By default this is just an alias
+    for 'shibboleth.DefaultEncryptionCredentials'. It could be re-defined as
+    a list with additional credentials if needed.
+    -->
+    <alias alias="shibboleth.EncryptionCredentials" name="shibboleth.DefaultEncryptionCredentials" />
+        
+    <!-- Your IdP's default encryption (really decryption) keys, set via property file. -->
+    <util:list id="shibboleth.DefaultEncryptionCredentials">
+        <bean class="net.shibboleth.idp.profile.spring.factory.BasicX509CredentialFactoryBean"
+            p:privateKeyResource="%{idp.encryption.key}"
+            p:certificateResource="%{idp.encryption.cert}"
+            p:entityId-ref="entityID" />
+
+        <!--
+        For key rollover, uncomment and point to your original keypair, and use the one above
+        to point to your new keypair. Once metadata has propagated, comment this one out again.
+        -->
+        <!--
+        <bean class="net.shibboleth.idp.profile.spring.factory.BasicX509CredentialFactoryBean"
+            p:privateKeyResource="%{idp.encryption.key.2}"
+            p:certificateResource="%{idp.encryption.cert.2}"
+            p:entityId-ref="entityID" />
+        -->
+    </util:list>
+
+</beans>

--- a/assets/idp.example.edu.dist/idp/conf/idp.properties
+++ b/assets/idp.example.edu.dist/idp/conf/idp.properties
@@ -94,7 +94,7 @@ idp.encryption.cert= %{idp.home}/credentials/idp-encryption.crt
 # Regular expression matching login flows to enable, e.g. IPAddress|Password
 # Enable ShibCas if you want to off-load authentication to your CAS IdP.
 idp.authn.flows= Password
-#idp.authn.flows= ShibCas
+#idp.authn.flows= Shibcas
 
 # CAS Client properties (usage loosely matches that of the Java CAS Client)
 ## CAS Server Properties

--- a/assets/idp.example.edu.dist/idp/conf/relying-party.xml
+++ b/assets/idp.example.edu.dist/idp/conf/relying-party.xml
@@ -47,6 +47,14 @@
         </property>
     </bean>
 
+    <!-- Uncomment if you need to support an older service that
+         does not support signing and encryption using SHA-256 -->
+
+    <!-- 
+    <bean id="SHA1SecurityConfig" parent="shibboleth.DefaultSecurityConfiguration"
+    p:signatureSigningConfiguration-ref="shibboleth.SigningConfiguration.SHA1" />
+    -->
+
     <!-- Container for any overrides you want to add. -->
 
     <util:list id="shibboleth.RelyingPartyOverrides">
@@ -65,6 +73,28 @@
         </bean>
         -->
         
+       <!--
+       Override example that ensures signing and encryption are performed 
+       using SHA-1. If you enable any services to use this configurtion you 
+       MUST also uncomment the "SHA1SecurityConfig" above.
+       -->
+       <!--
+       <bean parent="RelyingPartyByName" c:relyingPartyIds="https://sha1only.example.org">
+         <property name="profileConfigurations">
+             <list>
+                 <bean parent="Shibboleth.SSO" p:securityConfiguration-ref="SHA1SecurityConfig" />
+                 <bean parent="SAML1.AttributeQuery" p:securityConfiguration-ref="SHA1SecurityConfig" />
+                 <bean parent="SAML1.ArtifactResolution" p:securityConfiguration-ref="SHA1SecurityConfig" />
+                 <bean parent="SAML2.SSO" p:securityConfiguration-ref="SHA1SecurityConfig" />
+                 <bean parent="SAML2.ECP" p:securityConfiguration-ref="SHA1SecurityConfig" />
+                 <bean parent="SAML2.Logout" p:securityConfiguration-ref="SHA1SecurityConfig" />
+                 <bean parent="SAML2.AttributeQuery" p:securityConfiguration-ref="SHA1SecurityConfig" />
+                 <bean parent="SAML2.ArtifactResolution" p:securityConfiguration-ref="SHA1SecurityConfig" />
+             </list>
+         </property>
+       </bean>
+       -->
+
     </util:list>
 
 </beans>

--- a/tasks/idp.yml
+++ b/tasks/idp.yml
@@ -455,6 +455,14 @@
     group: jetty
     mode: 0640  
 
+- name: 'Set Shibboleth credentials.xml'
+  copy:
+    src: 'assets/{{inventory_hostname}}/idp/conf/credentials.xml'
+    dest: '{{ shib_idp.home }}/conf/credentials.xml'
+    owner: root
+    group: jetty
+    mode: 0640  
+
 - name: 'Set authn/general-authn.xml'
   copy:
     src: 'assets/{{inventory_hostname}}/idp/conf/authn/general-authn.xml'

--- a/tasks/jetty.yml
+++ b/tasks/jetty.yml
@@ -256,3 +256,9 @@
   with_items:
   - '{{ jetty.home }}/bin/jetty.sh'
 
+- name: 'Increase sleep time on jetty startup'
+  lineinfile:
+    dest: '{{ jetty.home }}/bin/jetty.sh'
+    regexp: 'sleep 4'
+    line: '    sleep 10'
+    backrefs: yes


### PR DESCRIPTION
Various minor fixes...

* This provides a link to AuthenticationFlow defined in authn/general-authn.xml
    Simple fix to a typo in a documented out option that is required for CAS integration.
* Extend sleep time in jetty.sh to allow startup to complete.
* Added option config to relying-party.xml to allow SP use SHA-1 signing and encryption

close #192 
close #19 
close #202