### PR TITLE
Tab replaced with spaces

### DIFF
--- a/update.yml
+++ b/update.yml
@@ -16,7 +16,7 @@
         state: directory
       with_items:
         - 'views'
-	- 'views/intercept'
+        - 'views/intercept'
         - 'messages'
         - 'webapp'
         - 'webapp/css'


### PR DESCRIPTION
As the PR name says... tab char causes Ansible to report an error when running the update-idp.sh with the -u option. This option causes the update.yml to be executed 