### PR TITLE
Bugfix/initial certs

### DIFF
--- a/tasks/idp-credentials.yml
+++ b/tasks/idp-credentials.yml
@@ -1,4 +1,23 @@
 ---
+- name: 'Backup IdP 3.x credentails only if they have not been backed up'
+  copy:
+    src: '{{ shib_idp.home }}/credentials'
+    dest: 'assets/{{ inventory_hostname }}/idp/credentials/{{ item }}'
+    owner: root
+    group: root
+    mode: 0644
+    force: no
+  with_items:
+  - idp-backchannel.crt
+  - idp-backchannel.p12
+  - idp-encryption.crt
+  - idp-encryption.key
+  - idp-signing.crt
+  - idp-signing.key
+  - idp-backchannel.p12
+  - sealer.jks
+  - sealer.kver
+
 - name: 'Restore IdP 3.x credentials'
   copy:
     src: 'assets/{{ inventory_hostname }}/idp/credentials/{{ item }}'

--- a/tasks/idp-credentials.yml
+++ b/tasks/idp-credentials.yml
@@ -1,8 +1,8 @@
 ---
 - name: 'Backup IdP 3.x credentails only if they have not been backed up'
   copy:
-    src: '{{ shib_idp.home }}/credentials'
-    dest: 'assets/{{ inventory_hostname }}/idp/credentials/{{ item }}'
+    src: '{{ shib_idp.home }}/credentials/{{ item }}'
+    dest: 'assets/{{ inventory_hostname }}/idp/credentials'
     owner: root
     group: root
     mode: 0644

--- a/tasks/idp.yml
+++ b/tasks/idp.yml
@@ -599,14 +599,14 @@
     group: jetty
     mode: 0640
 
-- name: 'Determine if credentials from previous install exist'
-  local_action:
-    module: stat
-    path: 'assets/{{ inventory_hostname }}/idp/credentials'
-  register: idp_credentials
+# - name: 'Determine if credentials from previous install exist'
+#   local_action:
+#     module: stat
+#     path: 'assets/{{ inventory_hostname }}/idp/credentials'
+#   register: idp_credentials
 
 - include: idp-credentials.yml
-  when: idp_credentials.stat.exists
+#  when: idp_credentials.stat.exists
 
 - name: 'Fix IdP dir permissions'
   file:

--- a/tasks/idp.yml
+++ b/tasks/idp.yml
@@ -599,14 +599,7 @@
     group: jetty
     mode: 0640
 
-# - name: 'Determine if credentials from previous install exist'
-#   local_action:
-#     module: stat
-#     path: 'assets/{{ inventory_hostname }}/idp/credentials'
-#   register: idp_credentials
-
 - include: idp-credentials.yml
-#  when: idp_credentials.stat.exists
 
 - name: 'Fix IdP dir permissions'
   file:

--- a/templates/jetty/jetty.xml
+++ b/templates/jetty/jetty.xml
@@ -111,7 +111,7 @@
              <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
            </Item>
            <Item>
-             <New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler"/>
+             <New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler"> <Set name="serveIcon">false</Set> </New>
            </Item>
          </Array>
         </Set>


### PR DESCRIPTION
Now grabs IdP certs from the IdP into the Assets area if there are no certificates in the Assets area. Generally will only occur when building a new IdP.

Added config to stop jetty displaying its default favicon

Ensures certificates are always available to copy back into the IdP.

Tested on new install and update.

close #215
close #217  