### PR TITLE
Bugfix/file protection

### DIFF
--- a/tasks/idp.yml
+++ b/tasks/idp.yml
@@ -136,9 +136,6 @@
     url: '{{ urls.aaf_shib_ext.url }}'
     dest: '{{ shib_idp.libs }}/aaf-shib-ext-{{ download.aaf_shib_ext.version }}.jar'
     sha256sum: '{{ download.aaf_shib_ext.sha256sum }}'
-    owner: root
-    group: jetty
-    mode: 0640
 
 - name: 'Link to aaf-shib-ext library'
   file:
@@ -151,9 +148,6 @@
     url: '{{ urls.cas_client_core.url }}'
     dest: '{{ shib_idp.libs }}/cas-client-core-{{ download.cas_client_core.version }}.jar'
     sha256sum: '{{ download.cas_client_core.sha256sum }}'
-    owner: root
-    group: jetty
-    mode: 0640
 
 - name: 'Link to cas-client-core library'
   file:
@@ -166,9 +160,6 @@
     url:  '{{ urls.shib_cas_authenticator.url }}'
     dest: '{{ shib_idp.libs }}/shib-cas-authenticator-{{ download.shib_cas_authenticator.version }}.jar'
     sha256sum: '{{ download.shib_cas_authenticator.sha256sum }}'
-    owner: root
-    group: jetty
-    mode: 0640
 
 - name: 'Link to shib-cas-authenticator library'
   file:
@@ -206,13 +197,6 @@
 - name: 'Copy over commons-dbcp2 lib'
   command: 'cp {{ installer.path }}/commons-dbcp2-{{ download.commons_dbcp2.version }}/commons-dbcp2-{{ download.commons_dbcp2.version }}.jar {{ shib_idp.libs }}/ creates="{{ shib_idp.libs }}/commons-dbcp2-{{ download.commons_dbcp2.version }}.jar"'
 
-- name: 'Set commons-dbcp2 ownership and protection'
-  file:
-    name: '{{ shib_idp.libs }}/commons-dbcp2-{{ download.commons_dbcp2.version }}.jar'
-    owner: root
-    group: jetty
-    mode: 0640
-
 - name: 'Link to commons-dbcp2 lib'
   file:
     name: '{{ shib_idp.home }}/edit-webapp/WEB-INF/lib/commons-dbcp2.jar'
@@ -233,13 +217,6 @@
 
 - name: 'Copy over commons-pool2 lib'
   command: 'cp {{ installer.path }}/commons-pool2-{{ download.commons_pool2.version }}/commons-pool2-{{ download.commons_pool2.version }}.jar {{ shib_idp.libs }}/ creates="{{ shib_idp.libs }}/commons-pool2-{{ download.commons_pool2.version }}.jar"'
-
-- name: 'Set commons-pool2 ownership and protection'
-  file:
-    name: '{{ shib_idp.libs }}/commons-pool2-{{ download.commons_pool2.version }}.jar'
-    owner: root
-    group: jetty
-    mode: 0640
 
 - name: 'Link to commons-pool2 lib'
   file:
@@ -332,9 +309,6 @@
     url: '{{ urls.mysql_connector.url }}'
     dest: '{{ installer.path }}/mysql-connector-java-{{ download.mysql_connector.version }}.tar.gz'
     sha256sum: '{{ download.mysql_connector.sha256sum }}'
-    owner: root
-    group: jetty
-    mode: 0740
 
 - name: 'Extract mysql connector library distribution'
   shell: >
@@ -344,13 +318,6 @@
 
 - name: 'Copy over mysql connector lib'
   command: 'cp {{ installer.path }}/mysql-connector-java-{{ download.mysql_connector.version }}/mysql-connector-java-{{ download.mysql_connector.version }}-bin.jar {{ shib_idp.libs }}/ creates="{{ shib_idp.libs }}/mysql-connector-java-{{ download.mysql_connector.version }}-bin.jar"'
-
-- name: 'Set  mysql connector lib ownership and protection'
-  file: 
-    name: '{{ shib_idp.libs }}/mysql-connector-java-{{ download.mysql_connector.version }}-bin.jar'
-    owner: root
-    group: jetty
-    mode: 0640
 
 - name: 'Link to mysql connector lib'
   file:
@@ -648,6 +615,20 @@
     mode: 0775
   with_items:
    - metadata
+
+- name: 'Fix IdP libs permissions and ownership'
+  file:
+    name: '{{ shib_idp.libs }}/{{ item }}'
+    owner: root
+    group: jetty
+    mode: 0640
+  with_items:
+  - 'aaf-shib-ext-{{ download.aaf_shib_ext.version }}.jar' 
+  - 'cas-client-core-{{ download.cas_client_core.version }}.jar'
+  - 'shib-cas-authenticator-{{ download.shib_cas_authenticator.version }}.jar'
+  - 'commons-dbcp2-{{ download.commons_dbcp2.version }}.jar'
+  - 'commons-pool2-{{ download.commons_pool2.version }}.jar'
+  - 'mysql-connector-java-{{ download.mysql_connector.version }}-bin.jar'
 
 - name: 'Fix IdP file permissions'
   file:

--- a/tasks/idp.yml
+++ b/tasks/idp.yml
@@ -232,11 +232,11 @@
     creates={{ installer.path }}/commons-pool2-{{ download.commons_pool2.version }}/commons-pool2-{{ download.commons_pool2.version }}.jar
 
 - name: 'Copy over commons-pool2 lib'
-  command: 'cp {{ installer.path }}/commons-pool2-{{ download.commons_pool2.version }}/commons-pool2-{{ download.commons_pool2.version }}.jar {{ shib_idp.libs }}/ creates="{{ shib_idp.home }}/commons-pool2-{{ download.commons_pool2.version }}.jar"'
+  command: 'cp {{ installer.path }}/commons-pool2-{{ download.commons_pool2.version }}/commons-pool2-{{ download.commons_pool2.version }}.jar {{ shib_idp.libs }}/ creates="{{ shib_idp.libs }}/commons-pool2-{{ download.commons_pool2.version }}.jar"'
 
 - name: 'Set commons-pool2 ownership and protection'
   file:
-    name: '{{ shib_idp.home }}/commons-pool2-{{ download.commons_pool2.version }}.jar'
+    name: '{{ shib_idp.libs }}/commons-pool2-{{ download.commons_pool2.version }}.jar'
     owner: root
     group: jetty
     mode: 0640

--- a/tasks/idp.yml
+++ b/tasks/idp.yml
@@ -136,6 +136,9 @@
     url: '{{ urls.aaf_shib_ext.url }}'
     dest: '{{ shib_idp.libs }}/aaf-shib-ext-{{ download.aaf_shib_ext.version }}.jar'
     sha256sum: '{{ download.aaf_shib_ext.sha256sum }}'
+    owner: root
+    group: jetty
+    mode: 0640
 
 - name: 'Link to aaf-shib-ext library'
   file:
@@ -148,6 +151,9 @@
     url: '{{ urls.cas_client_core.url }}'
     dest: '{{ shib_idp.libs }}/cas-client-core-{{ download.cas_client_core.version }}.jar'
     sha256sum: '{{ download.cas_client_core.sha256sum }}'
+    owner: root
+    group: jetty
+    mode: 0640
 
 - name: 'Link to cas-client-core library'
   file:
@@ -160,6 +166,9 @@
     url:  '{{ urls.shib_cas_authenticator.url }}'
     dest: '{{ shib_idp.libs }}/shib-cas-authenticator-{{ download.shib_cas_authenticator.version }}.jar'
     sha256sum: '{{ download.shib_cas_authenticator.sha256sum }}'
+    owner: root
+    group: jetty
+    mode: 0640
 
 - name: 'Link to shib-cas-authenticator library'
   file:
@@ -172,6 +181,9 @@
     url: '{{ urls.dta_ssl.url }}'
     dest:  '{{ shib_idp.libs }}/jetty-dta-ssl-{{ download.dta_ssl.version }}.jar'
     sha256sum: '{{ download.dta_ssl.sha256sum }}'
+    owner: root
+    group: jetty
+    mode: 0640
 
 - name: 'Link to jetty-dta-ssl library'
   file:
@@ -194,6 +206,13 @@
 - name: 'Copy over commons-dbcp2 lib'
   command: 'cp {{ installer.path }}/commons-dbcp2-{{ download.commons_dbcp2.version }}/commons-dbcp2-{{ download.commons_dbcp2.version }}.jar {{ shib_idp.libs }}/ creates="{{ shib_idp.libs }}/commons-dbcp2-{{ download.commons_dbcp2.version }}.jar"'
 
+- name: 'Set commons-dbcp2 ownership and protection'
+  file:
+    name: '{{ shib_idp.libs }}/commons-dbcp2-{{ download.commons_dbcp2.version }}.jar'
+    owner: root
+    group: jetty
+    mode: 0640
+
 - name: 'Link to commons-dbcp2 lib'
   file:
     name: '{{ shib_idp.home }}/edit-webapp/WEB-INF/lib/commons-dbcp2.jar'
@@ -214,6 +233,13 @@
 
 - name: 'Copy over commons-pool2 lib'
   command: 'cp {{ installer.path }}/commons-pool2-{{ download.commons_pool2.version }}/commons-pool2-{{ download.commons_pool2.version }}.jar {{ shib_idp.libs }}/ creates="{{ shib_idp.home }}/commons-pool2-{{ download.commons_pool2.version }}.jar"'
+
+- name: 'Set commons-pool2 ownership and protection'
+  file:
+    name: '{{ shib_idp.home }}/commons-pool2-{{ download.commons_pool2.version }}.jar'
+    owner: root
+    group: jetty
+    mode: 0640
 
 - name: 'Link to commons-pool2 lib'
   file:
@@ -306,6 +332,9 @@
     url: '{{ urls.mysql_connector.url }}'
     dest: '{{ installer.path }}/mysql-connector-java-{{ download.mysql_connector.version }}.tar.gz'
     sha256sum: '{{ download.mysql_connector.sha256sum }}'
+    owner: root
+    group: jetty
+    mode: 0740
 
 - name: 'Extract mysql connector library distribution'
   shell: >
@@ -315,6 +344,13 @@
 
 - name: 'Copy over mysql connector lib'
   command: 'cp {{ installer.path }}/mysql-connector-java-{{ download.mysql_connector.version }}/mysql-connector-java-{{ download.mysql_connector.version }}-bin.jar {{ shib_idp.libs }}/ creates="{{ shib_idp.libs }}/mysql-connector-java-{{ download.mysql_connector.version }}-bin.jar"'
+
+- name: 'Set  mysql connector lib ownership and protection'
+  file: 
+    name: '{{ shib_idp.libs }}/mysql-connector-java-{{ download.mysql_connector.version }}-bin.jar'
+    owner: root
+    group: jetty
+    mode: 0640
 
 - name: 'Link to mysql connector lib'
   file:
@@ -327,6 +363,9 @@
     url: '{{ urls.keystore.url }}'
     dest: '{{ jetty.base }}/etc/keystore'
     sha256sum: '{{ download.keystore.sha256sum }}'
+    owner: root
+    group: jetty
+    mode: 0740
 
 - name: 'Set jetty.base file permissions'
   file:


### PR DESCRIPTION
To ensure all files managed by the installer have specific file ownership and protection setting, This avoid issues caused where root has an unexpected umask value. 

close #222 