### PR TITLE
Ownership modified for Symlinks

### DIFF
--- a/tasks/idp.yml
+++ b/tasks/idp.yml
@@ -374,8 +374,8 @@
     name: '{{ shib_idp.home }}/logs'
     src: /var/log/shibboleth-idp
     state: link
-    owner: root
-    group: root
+    owner: jetty
+    group: jetty
     force: yes
 
 - name: 'Symlink IdP src directory'
@@ -384,7 +384,7 @@
     src: '{{ shib_idp.src }}'
     state: link
     owner: root
-    group: root
+    group: jetty
     force: yes
 
 - name: 'Symlink IdP instance directory'
@@ -409,8 +409,8 @@
     name: '{{ jetty.base }}/logs'
     src: /var/log/jetty
     state: link
-    owner: root
-    group: root
+    owner: jetty
+    group: jetty
     force: yes
 
 - name: 'Set metadata provider'

--- a/tasks/jetty.yml
+++ b/tasks/jetty.yml
@@ -37,7 +37,7 @@
     name: '{{ jetty.current }}'
     src: '{{ jetty.home }}'
     owner: root
-    group: root
+    group: jetty
     state: link
     force: yes
 


### PR DESCRIPTION
This it the first in a series of PR that will eventually upgrade the installers to install v3.4.1 of Shibboleth. This PR fixes issues with symbolic links that appeared with an upgrade to Ansible.

Closes #242 