### PR TITLE
Bugfix/jetty startup

### DIFF
--- a/README_libraries.md
+++ b/README_libraries.md
@@ -6,10 +6,10 @@ file documents these libraries.
 
 | Library | Current Version | Latest Version | Source |
 | ------- | --------------- | -------------- | ------ |
-| Connector-J | 5.1.35 | 5.1.41 | https://dev.mysql.com/downloads/connector/j/ |
+| Connector-J | 5.1.35 | 8.0.12 | https://dev.mysql.com/downloads/connector/j/ |
 | jetty9-dta-ssl | 1.0.0 | 1.0.0 | https://build.shibboleth.net/nexus/content/repositories/releases/net/shibboleth/utilities/jetty9/jetty9-dta-ssl/ |
-| commons_dbcp2 | 2.1.1 | 2.1.1 | https://commons.apache.org/proper/commons-dbcp/download_dbcp.cgi |
-| commons_pool2 | 2.4.2 | 2.4.2 | https://commons.apache.org/proper/commons-pool/download_pool.cgi |
+| commons_dbcp2 | 2.1.1 | 2.5.0 | https://commons.apache.org/proper/commons-dbcp/download_dbcp.cgi |
+| commons_pool2 | 2.4.2 | 2.6.0 | https://commons.apache.org/proper/commons-pool/download_pool.cgi |
 | aaf_shib_ext | 1.0.1 | 1.1.1 | AAF |
 | cas_client_core | 3.3.3 | 3.4.1 | https://github.com/Unicon/shib-cas-authn3/releases |
-| shib_cas_authenticator | 3.0.0 | 3.2.1 | https://github.com/Unicon/shib-cas-authn3/releases |
+| shib_cas_authenticator | 3.0.0 | 3.2.3 | https://github.com/Unicon/shib-cas-authn3/releases |

--- a/assets/idp.example.edu.dist/apache/idp.conf
+++ b/assets/idp.example.edu.dist/apache/idp.conf
@@ -21,6 +21,14 @@ Listen 443
   ErrorLog logs/ssl_error_log
   LogLevel warn
 
+# By default the web server will respond with the message "Forbidded You don't
+# have permission to access / on this server.". You can change this behavious 
+# by uncommenting the following line of configuration and setting an appropriate
+# URL to redirect the user to if they attempt to navigate to the base URL of this
+# web server.
+
+# RedirectMatch 301 ^/$ http://example.com/ 
+ 
 # The following configuration is based on the Intermediate compatibility (default)
 # configuration as descibed at Security/Server Side TLS
 # See: https://wiki.mozilla.org/Security/Server_Side_TLS for details.

--- a/bin/fix_tb_st.sql
+++ b/bin/fix_tb_st.sql
@@ -1,0 +1,45 @@
+-- Updates the characater set and collation used on the tb_st table
+-- to allow for a wider range of characters to be catered for.
+--
+-- For MySQL and MariaDB databases only, version 5.5 or greater.
+--
+-- Login to the database connected to the idp_db schema and load the
+-- the fix_tb_st procedure.
+--
+--     mysql idb_db
+--     source fix_tb_st.sql
+--     call fix_tb_st ([ture|false])
+-- 
+ 
+DROP PROCEDURE IF EXISTS fix_tb_st;
+
+DELIMITER //
+
+CREATE PROCEDURE fix_tb_st (IN dorun boolean)
+BEGIN
+  select column_name as 'Column', 
+         @tb_st_charset := character_set_name as 'Current Character Set', 
+         @tb_st_collation := collation_name as 'Current Collation'
+  from information_schema.columns where table_name = 'tb_st';
+
+  if (@tb_st_charset != 'utf8mb4' or @tb_st_collation != 'utf8mb4_bin') then
+
+    if (!dorun) then
+      select 'Change of character set required!' as 'Result';
+    else
+        alter table tb_st  default character set utf8mb4 default collate utf8mb4_bin;
+
+        alter table tb_st convert to character set utf8mb4 collate utf8mb4_bin;
+
+        select 'Table successfully modified' as 'Result';
+    end if;
+
+  else
+    select 'Database Ok, change is NOT required!' as 'Result';
+
+  end if;
+
+
+END//
+
+DELIMITER ;

--- a/site.yml
+++ b/site.yml
@@ -6,28 +6,28 @@
     download:
       jetty:
         baseurl: "{{ aaf_binaries.baseurl }}/jetty"
-        version: 9.4.8.v20171121
-        sha256sum: 50d6bdedd3f57923516661019aed2f5ef89b394d09bffdb04786ccb6c1897c2f
+        version: 9.4.12.v20180830
+        sha256sum: 03c7b8cc5702b52173afad56b3c40e5e5dcf22cca23c1423b99486bb3b4389fc
       shib_idp:
         baseurl: "{{ aaf_binaries.baseurl }}/shibboleth"
-        version: 3.3.2
-        sha256sum: ed9fbefd273199d2841d4045b2661671c53825ed3c7d52d38bfe516b39d5fc64
+        version: 3.3.3
+        sha256sum: 742a772f19e11c55af8a18f16463b736230fc447cd8c4aaf4bf242c5b074087c
       mysql_connector:
         baseurl: "{{ aaf_binaries.baseurl }}/jars/Connector-J"
-        version: 5.1.45
-        sha256sum: 1d289a056c7eb8290108a8d2e3c4717193662a9171adb56cfa3b769b32de3300
+        version: 8.0.12
+        sha256sum: 4aded8964442becb9c8fd84928af7c61b5882833750262049201b3061c623a36
       dta_ssl:
         baseurl: "{{ aaf_binaries.baseurl }}/jars/jetty9-dta-ssl"
         version: 1.0.0
         sha256sum: 9c62a5999d5adddea905d7caf4220fc073e6033b755f224084cc240dc8d992a6
       commons_dbcp2:
         baseurl: "{{ aaf_binaries.baseurl }}/jars/commons_dbcp2"
-        version: 2.1.1
-        sha256sum: d6181397b20490aa9b3a793a19c2b75f31af032040d976db1cd97cc2f0ef4379
+        version: 2.5.0
+        sha256sum: 2e9da64b97af50951a3ac14b2269993fd8de323e00265d0e6a952fc108f05a22
       commons_pool2:
         baseurl: "{{ aaf_binaries.baseurl }}/jars/commons_pool2"
-        version: 2.4.2
-        sha256sum: 175ddacc9364b4619ac0fd0fd22acc9d4c372f9099ae5208e8cb72e04a9a872e
+        version: 2.6.0
+        sha256sum: 961606add45d4212951482327d6b541214af1f95ea21b0528628eb031a4af522
       aaf_shib_ext:
         baseurl: "{{ aaf_binaries.baseurl }}/jars/aaf_shib_ext"
         version: 1.1.1

--- a/tasks/db.yml
+++ b/tasks/db.yml
@@ -6,6 +6,22 @@
     group: mysql
     mode: 0700
 
+- name: 'Create /etc/mysql'
+  file:
+    dest: /etc/mysql
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: 'Write /etc/mysql/my.cnf'
+  template:
+    src: templates/db/my.cnf
+    dest: /etc/mysql/my.cnf
+    owner: root
+    group: root
+    mode: 0644
+
 - name: 'Start database server'
   service:
     name: mariadb
@@ -37,8 +53,8 @@
   mysql_db:
     login_unix_socket: /var/lib/mysql/mysql.sock
     name: '{{ db.name }}'
-    collation: utf8_general_ci
-    encoding: utf8
+    collation: utf8mb4_general_ci
+    encoding: utf8mb4
     state: present
 
 - name: 'Create db user'

--- a/tasks/idp.yml
+++ b/tasks/idp.yml
@@ -332,15 +332,15 @@
   shell: >
     umask 0027;
     tar zx -C {{ installer.path }} -f {{ installer.path }}/mysql-connector-java-{{ download.mysql_connector.version }}.tar.gz;
-    creates={{ installer.path }}/mysql-connector-java-{{ download.mysql_connector.version }}/mysql-connector-java-{{ download.mysql_connector.version }}-bin.jar
+    creates={{ installer.path }}/mysql-connector-java-{{ download.mysql_connector.version }}/mysql-connector-java-{{ download.mysql_connector.version }}.jar
 
 - name: 'Copy over mysql connector lib'
-  command: 'cp {{ installer.path }}/mysql-connector-java-{{ download.mysql_connector.version }}/mysql-connector-java-{{ download.mysql_connector.version }}-bin.jar {{ shib_idp.libs }}/ creates="{{ shib_idp.libs }}/mysql-connector-java-{{ download.mysql_connector.version }}-bin.jar"'
+  command: 'cp {{ installer.path }}/mysql-connector-java-{{ download.mysql_connector.version }}/mysql-connector-java-{{ download.mysql_connector.version }}.jar {{ shib_idp.libs }}/ creates="{{ shib_idp.libs }}/mysql-connector-java-{{ download.mysql_connector.version }}.jar"'
 
 - name: 'Link to mysql connector lib'
   file:
     name: '{{ jetty.base }}/lib/ext/mysql-connector-java-bin.jar'
-    src: '{{ shib_idp.libs }}/mysql-connector-java-{{ download.mysql_connector.version }}-bin.jar'
+    src: '{{ shib_idp.libs }}/mysql-connector-java-{{ download.mysql_connector.version }}.jar'
     state: link
 
 - name: 'Download placeholder keystore'
@@ -374,8 +374,8 @@
     name: '{{ shib_idp.home }}/logs'
     src: /var/log/shibboleth-idp
     state: link
-    owner: root
-    group: root
+    owner: jetty
+    group: jetty
     force: yes
 
 - name: 'Symlink IdP src directory'
@@ -384,7 +384,7 @@
     src: '{{ shib_idp.src }}'
     state: link
     owner: root
-    group: root
+    group: jetty
     force: yes
 
 - name: 'Symlink IdP instance directory'
@@ -393,7 +393,7 @@
     src: '{{ shib_idp.home }}'
     state: link
     owner: root
-    group: root
+    group: jetty
     force: yes
 
 - name: 'Create jetty log directory'
@@ -409,8 +409,8 @@
     name: '{{ jetty.base }}/logs'
     src: /var/log/jetty
     state: link
-    owner: root
-    group: root
+    owner: jetty
+    group: jetty
     force: yes
 
 - name: 'Set metadata provider'

--- a/tasks/jetty.yml
+++ b/tasks/jetty.yml
@@ -37,7 +37,7 @@
     name: '{{ jetty.current }}'
     src: '{{ jetty.home }}'
     owner: root
-    group: root
+    group: jetty
     state: link
     force: yes
 

--- a/tasks/jetty.yml
+++ b/tasks/jetty.yml
@@ -255,10 +255,3 @@
     mode: 0750
   with_items:
   - '{{ jetty.home }}/bin/jetty.sh'
-
-- name: 'Increase sleep time on jetty startup'
-  lineinfile:
-    dest: '{{ jetty.home }}/bin/jetty.sh'
-    regexp: 'sleep 4'
-    line: '    sleep 10'
-    backrefs: yes

--- a/templates/db/my.cnf
+++ b/templates/db/my.cnf
@@ -1,0 +1,7 @@
+[mysqld]
+character-set-server = utf8
+interactive_timeout = 31536000
+wait_timeout=31536000
+
+[client]
+default-character-set = utf8

--- a/templates/db/tb_st_ddl.sql
+++ b/templates/db/tb_st_ddl.sql
@@ -2,5 +2,5 @@ create table if not exists tb_st(
   uid varchar(100) not null,
   sharedtoken varchar(50),
   primary key (uid)
-);
+) DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE utf8mb4_bin;
 

--- a/templates/db/tb_storage_records_ddl.sql
+++ b/templates/db/tb_storage_records_ddl.sql
@@ -5,4 +5,4 @@ create table if not exists StorageRecords(
   value longtext not null,
   version bigint(20) not null,
   primary key (context,id)
-)
+) DEFAULT CHARSET=utf8;

--- a/templates/idp/idp.service
+++ b/templates/idp/idp.service
@@ -3,6 +3,7 @@ Description=Shibboleth Identity Provider
 After=syslog.target network.target mariadb.target
 
 [Service]
+Environment=JETTY_START_TIMEOUT=360
 ExecStart=/bin/bash -c "{{ install_base }}/jetty/current/bin/jetty.sh start"
 ExecStop=/bin/bash -c "{{ install_base }}/jetty/current/bin/jetty.sh stop"
 RemainAfterExit=yes

--- a/templates/jetty/jetty.xml
+++ b/templates/jetty/jetty.xml
@@ -131,8 +131,8 @@
         <Arg></Arg>
         <Arg>jdbc/shib_idp</Arg>
         <Arg>
-            <New class="com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource">
-                <Set name="Url">jdbc:mysql://localhost/{{ db.name }}?autoReconnect=true&amp;sessionVariables=wait_timeout=31536000</Set>
+            <New class="com.mysql.cj.jdbc.MysqlConnectionPoolDataSource">
+                <Set name="Url">jdbc:mysql://localhost/{{ db.name }}?autoReconnect=true</Set>
                 <Set name="User">{{ db.username }}</Set>
                 <Set name="Password">{{ db.password }}</Set>
             </New>


### PR DESCRIPTION
The fifth in the series to upgrade to v.3.4.1, follows #254. With the latest version of Jetty is an option to allow for to startup script to change the amount of time to wait for the IdP to start using an external environment variable. This removes the need to change the script using Ansible. With a clean startup the command systemctl status idp returns a valid result.

Closes #8 