### PR TITLE
Bugfix/mysql timezone option2

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -147,4 +147,7 @@
       service:
         name: httpd
         state: restarted
-
+    - name: Restart database
+      service:
+        name: mariadb
+        state: restarted

--- a/tasks/db.yml
+++ b/tasks/db.yml
@@ -21,6 +21,7 @@
     owner: root
     group: root
     mode: 0644
+  notify: 'Restart database'
 
 - name: 'Start database server'
   service:

--- a/templates/db/my.cnf
+++ b/templates/db/my.cnf
@@ -2,6 +2,7 @@
 character-set-server = utf8
 interactive_timeout = 31536000
 wait_timeout=31536000
+default-time-zone='+00:00'
 
 [client]
 default-character-set = utf8


### PR DESCRIPTION
Sets global timezone and restarts mariadb when /etc/mysql/my.cnf changes.