### PR TITLE
Feature/software upgrades

### DIFF
--- a/README_libraries.md
+++ b/README_libraries.md
@@ -6,10 +6,10 @@ file documents these libraries.
 
 | Library | Current Version | Latest Version | Source |
 | ------- | --------------- | -------------- | ------ |
-| Connector-J | 8.0.13 | 8.0.13 | https://dev.mysql.com/downloads/connector/j/ |
+| Connector-J | 8.0.16 | 8.0.16 | https://dev.mysql.com/downloads/connector/j/ |
 | jetty9-dta-ssl | 1.0.0 | 1.0.0 | https://build.shibboleth.net/nexus/content/repositories/releases/net/shibboleth/utilities/jetty9/jetty9-dta-ssl/ |
-| commons_dbcp2 | 2.5.0 | 2.5.0 | https://commons.apache.org/proper/commons-dbcp/download_dbcp.cgi |
-| commons_pool2 | 2.6.0 | 2.6.0 | https://commons.apache.org/proper/commons-pool/download_pool.cgi |
+| commons_dbcp2 | 2.6.0 | 2.6.0 | https://commons.apache.org/proper/commons-dbcp/download_dbcp.cgi |
+| commons_pool2 | 2.6.2 | 2.6.2 | https://commons.apache.org/proper/commons-pool/download_pool.cgi |
 | aaf_shib_ext | 1.1.1 | 1.1.1 | AAF |
 | cas_client_core | 3.4.1 | 3.4.1 | https://github.com/Unicon/shib-cas-authn3/releases |
 | shib_cas_authenticator | 3.2.3 | 3.2.3 | https://github.com/Unicon/shib-cas-authn3/releases |

--- a/site.yml
+++ b/site.yml
@@ -14,20 +14,20 @@
         sha256sum: 257af1ea443d5302c6baab348e93c5184196e4a39e2d8607f68daa8a768c5cce
       mysql_connector:
         baseurl: "{{ aaf_binaries.baseurl }}/jars/Connector-J"
-        version: 8.0.13
-        sha256sum: 99501fbc74b4cb80cd75a4d06c38b662be01bfd39c409efa3c747ec83216329b
+        version: 8.0.16
+        sha256sum: de7d7f8ce9d777c2a6c7c47695d87bfd635e621f9142467a5e56538fcaf4644a
       dta_ssl:
         baseurl: "{{ aaf_binaries.baseurl }}/jars/jetty9-dta-ssl"
         version: 1.0.0
         sha256sum: 9c62a5999d5adddea905d7caf4220fc073e6033b755f224084cc240dc8d992a6
       commons_dbcp2:
         baseurl: "{{ aaf_binaries.baseurl }}/jars/commons_dbcp2"
-        version: 2.5.0
-        sha256sum: 2e9da64b97af50951a3ac14b2269993fd8de323e00265d0e6a952fc108f05a22
+        version: 2.6.0
+        sha256sum: 56896038a278bb0fa69236cc20a51e75c77ac2fe97efdde9f2fcf0411f289cf1
       commons_pool2:
         baseurl: "{{ aaf_binaries.baseurl }}/jars/commons_pool2"
-        version: 2.6.0
-        sha256sum: 961606add45d4212951482327d6b541214af1f95ea21b0528628eb031a4af522
+        version: 2.6.2
+        sha256sum: 30a4248ea82e886d9d60a9afc0251da5bcb60633b1a2512fef83a78b7e708f75
       aaf_shib_ext:
         baseurl: "{{ aaf_binaries.baseurl }}/jars/aaf_shib_ext"
         version: 1.1.1

--- a/site.yml
+++ b/site.yml
@@ -6,12 +6,12 @@
     download:
       jetty:
         baseurl: "{{ aaf_binaries.baseurl }}/jetty"
-        version: 9.4.14.v20181114
-        sha256sum: c66abd7323f6df5b28690e145d2ae829dbd12b8a2923266fa23ab5139a9303c5
+        version: 9.4.18.v20190429
+        sha256sum: 0fb8735b5d23d3ad7350c19fc1523cf7eda1936d2cee2d4f85edfb27b3d7eaf7
       shib_idp:
         baseurl: "{{ aaf_binaries.baseurl }}/shibboleth"
-        version: 3.4.3
-        sha256sum: eb86bc7b6366ce2a44f97cae1b014d307b84257e3149469b22b2d091007309db
+        version: 3.4.4
+        sha256sum: 257af1ea443d5302c6baab348e93c5184196e4a39e2d8607f68daa8a768c5cce
       mysql_connector:
         baseurl: "{{ aaf_binaries.baseurl }}/jars/Connector-J"
         version: 8.0.13


### PR DESCRIPTION
Upgraded to latest Shibboleth 3.4.4 and Jetty 9.4.18 as well and upgraded an number of auxiliary libraries. This will resolve recent issues identified with Jetty (https://webtide.com/indexing-listing-vulnerability-in-jetty/).

Have tested as a new install and an upgrade from and ealier IdP without issue.

Resolves #278 #277 