### PR TITLE
Migration tool download wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ assets/*
 Vagrantfile
 vagrant_id_rsa
 **/*.swp
+.DS_Store
+.idea/
+rapid-idp-migrate/rapid-idp-migrate*.jar

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+> &nbsp;
+>
+> [<img src="https://aaf.edu.au/images/Rapid-IdP.png"  width="400"/>](https://aaf.edu.au/rapid/)
+>
+> Need a managed, secure and highly available Identity Provider solution?
+>
+> [Contact the AAF about Rapid IdP today.](https://aaf.edu.au/rapid/)
+>
+> &nbsp;
+
 # Shibboleth IdP Installer
 
 ## Overview
@@ -13,11 +23,3 @@ This version now enables the technical connection to eduGAIN, the global federat
 ## License
 Apache License Version 2.0, January 2004
 
----
-
-# AAF Rapid IdP
-Need a secure, highly available and feature rich Identity Provider solution?
-
-Contact the AAF about Rapid IdP today.  https://aaf.edu.au/rapid/
-
-[![](https://aaf.edu.au/images/Rapid-IdP.png)](https://aaf.edu.au/rapid/)

--- a/rapid-idp-migrate/README.md
+++ b/rapid-idp-migrate/README.md
@@ -14,6 +14,7 @@ $ ./rapid-idp-migrate --upload
 ### Manual download
 You should only need this if you don't want to update your installer.
 ```
+$ cd ~ # (or another working directory that is NOT the git repo)
 $ curl -O https://raw.githubusercontent.com/ausaccessfed/shibboleth-idp-installer/master/rapid-idp-migrate/rapid-idp-migrate
 $ chmod +x rapid-idp-migrate
 $ ./rapid-idp-migrate --help

--- a/rapid-idp-migrate/README.md
+++ b/rapid-idp-migrate/README.md
@@ -1,0 +1,20 @@
+# Rapid IdP Migrate
+
+```
+$ cd rapid-idp-migrate
+$ ./rapid-idp-migrate --help
+```
+
+To securely upload your configuration to Australian Access Federation servers
+
+```
+$ ./rapid-idp-migrate --upload
+```
+
+### Manual download
+You should only need this if you don't want to update your installer.
+```
+$ curl -O https://raw.githubusercontent.com/ausaccessfed/shibboleth-idp-installer/master/rapid-idp-migrate/rapid-idp-migrate
+$ chmod +x rapid-idp-migrate
+$ ./rapid-idp-migrate --help
+```

--- a/rapid-idp-migrate/rapid-idp-migrate
+++ b/rapid-idp-migrate/rapid-idp-migrate
@@ -4,15 +4,15 @@ set -e
 
 file="rapid-idp-migrate-latest.jar"
 uri="https://aaf-build-artifacts.s3-ap-southeast-2.amazonaws.com/rapid-idp-migrate/$file"
-dir=`dirname "$0"`
+dir=$(dirname "$0")
 local_file="$dir/$file"
 
 # Check if the jar file has ever been downloaded
-if test -e ${local_file}
+if test -e "${local_file}"
 then zflag=(-z "$local_file" -Ss) # Existing file. Check if newer exists.
 else zflag=() # Never existed. Show download progress (lack of -Ss).
 fi
 
 curl -o "$local_file" "${zflag[@]}" "$uri"
 
-java -jar ${local_file} $*
+java -jar "${local_file}" "$@"

--- a/rapid-idp-migrate/rapid-idp-migrate
+++ b/rapid-idp-migrate/rapid-idp-migrate
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 file="rapid-idp-migrate-latest.jar"
 uri="https://aaf-build-artifacts.s3-ap-southeast-2.amazonaws.com/rapid-idp-migrate/$file"
 dir=`dirname "$0"`

--- a/rapid-idp-migrate/rapid-idp-migrate
+++ b/rapid-idp-migrate/rapid-idp-migrate
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+file="rapid-idp-migrate-latest.jar"
+uri="https://aaf-build-artifacts.s3-ap-southeast-2.amazonaws.com/rapid-idp-migrate/$file"
+dir=`dirname "$0"`
+local_file="$dir/$file"
+
+# Check if the jar file has ever been downloaded
+if test -e ${local_file}
+then zflag=(-z "$local_file" -Ss) # Existing file. Check if newer exists.
+else zflag=() # Never existed. Show download progress (lack of -Ss).
+fi
+
+curl -o "$local_file" "${zflag[@]}" "$uri"
+
+java -jar ${local_file} $*


### PR DESCRIPTION
Download and run jar with wrapper

- Doesn't store binary in the git repo
- Updates the jar if a newer version exists (based off file times)

Jars:
<img width="395" alt="Screen Shot 2019-07-03 at 11 07 20 am" src="https://user-images.githubusercontent.com/144163/60556041-c2bd3580-9d82-11e9-8ae5-a771949f3de0.png">
