### PR TITLE
Updates versions of Shibboleth and Jetty

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -28,12 +28,12 @@
     download:
       jetty:
         baseurl: "{{ aaf_binaries.baseurl }}/jetty"
-        version: 9.4.18.v20190429
-        sha256sum: 0fb8735b5d23d3ad7350c19fc1523cf7eda1936d2cee2d4f85edfb27b3d7eaf7
+        version: 9.4.20.v20190813
+        sha256sum: 258999e71bdfc8768db88f0253c2f53c282ae2dc0294723f91a3243be8ddcea2
       shib_idp:
         baseurl: "{{ aaf_binaries.baseurl }}/shibboleth"
-        version: 3.4.4
-        sha256sum: 257af1ea443d5302c6baab348e93c5184196e4a39e2d8607f68daa8a768c5cce
+        version: 3.4.5
+        sha256sum: 75a200b06be459db8f195caa40d5acc01e133cad9ebcc65cf00c324ae8321c4b
       mysql_connector:
         baseurl: "{{ aaf_binaries.baseurl }}/jars/Connector-J"
         version: 8.0.16


### PR DESCRIPTION
Update to version of Shibboleth to 3.4.5 in response to Shibboleth security patch, and update to latest version of Jetty.

Installer has been successfully tested for a new install and upgrading an existing installation.